### PR TITLE
docs: words around important/negative messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Both Social Team members and Node.js project collaborators submitting PRs should
 - We do not amplify or share content that could unduly promote or benefit one corporation that does work in the space of Node.js over another.
 - Where possible, we try to amplify the collaborators who are doing the work rather than anonymously taking credit for it as the project.
   - As an example, we try to amplify those on the Release Team who are cutting releases directly rather than tweeting release announcements directly from the project's account.
+  - As an exception, in the case where important or potentially negative content is being shared, using the main account's voice is preferable to both reduce potential negative impact on the indivduals we'd be amplifying and increase the message's signal to end-users (seeing someone you don't know vs. seeing the account have different levels of impact).
 - We aim to support and amplify ecosystem members who are doing interesting and nice work.
 
 This list should not be expected to be comprehensive nor exclusive, and may be clarified, ammended, or otherwise modified to ensure that the way the Social Team works in the context of our Twitter account is well represented here.


### PR DESCRIPTION
adds some wording around tweets for impactful or negative communication.

specifically, an example of where this would be applicable is something like a security release where there's the _potential_ for harm to end-users. it's preferable that we use the account's voice directly rather than amplifying individuals to reduce the potential for individuals to be targeted *and* for the message to have a higher signal to noise ratio.

on the signal to noise ratio, effectively what I'm saying is that a tweet from @nodejs will be more *obvious* and *engaged* than that of an individual. readers don't need to wonder who they're looking at or why they're an authority - the account disambiguates a lot, making the message land more strongly.