### PR TITLE
Use NodeJS bot token for hiring tweets

### DIFF
--- a/.github/workflows/hiring-tweet.yml
+++ b/.github/workflows/hiring-tweet.yml
@@ -18,7 +18,7 @@ jobs:
       - run: "node ./scripts/recurring/hiring.js" # run the hiring tweet tweet builder
       - uses: gr2m/create-or-update-pull-request-action@v1.x # create a PR or update the Action's existing PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NODEJS_TWEET }}
         with:
           title: "tweet: monthly hiring tweet"
           body: "Here's the monthly hiring tweet. Please review and then ship it."


### PR DESCRIPTION
In https://github.com/nodejs/tweet/pull/10#pullrequestreview-599902564, the author of the tweeting script used in this repo commented that GitHub actions were not being triggered by your custom build/hiring tweet generation scripts. This was because it used a GitHub actions provided token instead of a (bot) user token.

After this, you obtained a token for a bot user (see nodejs/admin issue #585, which is still open and should probably be reviewed/flagged as resolved) and added it to your build tweet generator in commit dea74537a89914f4fdd64fe96ffa27ee61cdfcdd. For whatever reason, the change wasn't applied to the hiring tweet generator.

This PR applies the same change to your hiring tweet generator. By using the same PR creator, you can filter for automated tweets by author going forward, in the event this PR were to be merged.

Feel free to make whatever changes are necessary to this PR/close it at your discretion if you do not want to take this onboard. 