### PR TITLE
scripts: add recurring update reminder tweet script

### DIFF
--- a/.github/workflows/update-tweet.yml
+++ b/.github/workflows/update-tweet.yml
@@ -1,0 +1,27 @@
+on:
+  schedule:
+    # At 09:00 every day.
+    # https://crontab.guru/#0_9_*_*_*
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+name: Create Version Update Tweet
+jobs:
+  create-build-tweet:
+    if: github.repository == 'nodejs/tweet'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - run: "node ./scripts/recurring/update.js" # run the build tweet tweet builder
+      - uses: gr2m/create-or-update-pull-request-action@v1.x # create a PR or update the Action's existing PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.NODEJS_TWEET }}
+        with:
+          title: "tweet: version update reminder tweet"
+          body: "Here's a reminder tweet to update Node.js versions"
+          branch: actions/build
+          commit-message: 'tweet: version update reminder tweet'
+          labels: tweet

--- a/scripts/recurring/update.js
+++ b/scripts/recurring/update.js
@@ -1,0 +1,55 @@
+const writeTweet = require('../writeTweet')
+
+const warningDayOffsets = {
+  lts: [90, 30, 7, 0],
+  maintenance: [90, 30, 7, 3, 0],
+  end: [30, 7, 3, 0]
+}
+
+const statusMessage = {
+  lts: 'enters LTS',
+  maintenance: 'enters maintenance',
+  end: 'is end-of-life'
+}
+
+function warningMessage (warning) {
+  return [
+    warning.version,
+    statusMessage[warning.type],
+    warning.days ? `in ${warning.days} days` : 'today'
+  ].join(' ')
+}
+
+fetch('https://raw.githubusercontent.com/nodejs/Release/main/schedule.json')
+  .then(data => data.json())
+  .catch(() => ({}))
+  .then(schedules => {
+    const warnings = []
+
+    for (const [version, schedule] of Object.entries(schedules)) {
+      for (const [type, dayOffsets] of Object.entries(warningDayOffsets)) {
+        for (const days of dayOffsets) {
+          const d = new Date()
+          d.setUTCHours(0, 0, 0, 0)
+          d.setDate(d.getDate() + days)
+
+          if (d.getTime() === Date.parse(schedule[type])) {
+            warnings.push({
+              lts: Object.hasOwn(schedule, 'lts'),
+              version,
+              type,
+              days
+            })
+          }
+        }
+      }
+    }
+
+    if (!warnings.length) return
+
+    const tweet = `It might be time to update your Node.js! ⏰
+    
+${warnings.map(warningMessage).join('\n')}`
+
+    writeTweet('eol', tweet)
+  })


### PR DESCRIPTION
Fixes #78

This is a quick and dirty solution which combines messages for each state transition (entering LTS, entering maintenance, and reaching end-of-life) into a single message. I just picked some random day offsets for warnings, but we may want to think more carefully about those.