### PR TITLE
chore: add note about images and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This list should not be expected to be comprehensive nor exclusive, and may be c
 ### Other tips for tweets:
 
 - If you are driving folks to a link, place that link at the end of the tweet so that Twitter displays the content as a Twitter Card.
+- If you are including a link, do not include an image. Doing so dramatically (double digit percentages) reduces engagement with that link.
 - Are you trying to get people to take some sort of action? (Read blog post, participate in an event, etc...) If so, then make that "call to action" text clear and use encouraging language.
 
 ## Request a tweet from the [@nodejs](https://twitter.com/nodejs) Twitter account


### PR DESCRIPTION
Wanted to further clarify/document basic best practices around sharing links so we don't artificially limit our own engagement.

Adding an image when you've got a link that can turn into a Twitter Card hurts the click through rate on that link in the double digits. It can also be inferred from Twitter's developer site that tweets with Twitter Cards get an algorithmic boost, which makes sense.

source: 8 years as a Developer Advocate who either directly runs corporate (and corporate open source) Twitter accounts or advises those who do.